### PR TITLE
Configure Git LFS for recipe images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/images/recipes/*.png filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- add a `.gitattributes` entry to track recipe PNG assets with Git LFS
- ensure future `assets/images/recipes` PNG binaries are handled by LFS to avoid platform errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8f7d75bc4832ca47bfe53ba489eba